### PR TITLE
Successfully fixed digit count

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -19,7 +19,10 @@ var getBinaryTime = function(){
   var seconds = date.getSeconds().toString(2);
   var time = [hour, minutes, seconds];
   for(var ti = 0; ti < time.length; ti++){
-    for(var i = 9; i >= time[ti].length; i--){
+    console.log("ti: " + ti);
+    var startingLength = time[ti].length;
+    for(var i = 1; i <= (8 - startingLength); i++){
+      console.log("i: " + i + " max: " + (8 - startingLength));
       time[ti] = "0" + time[ti];
     }
   }


### PR DESCRIPTION
Originally accidentally used a dynamic count of each time string's length instead of the static value of the original length of each time string. This has now been fixed, and all strings now consist of 8 binary digits.